### PR TITLE
fix: invalidate jest, eslint, stylelint with failed tests

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -38,10 +38,10 @@ jobs:
 
     steps:
       - name: 🤘 Getting the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Installing node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -59,7 +59,12 @@ jobs:
           DD_ENV: ci
           NODE_OPTIONS: -r dd-trace/ci/init
         run: |
+          set +e
           yarn eslint --format junit --output-file eslint-output.xml 2> /dev/null || true
+          exitcode="$?"
+          
+          echo "exitcode=$?" >> $GITHUB_OUTPUT
+          exit "$exitcode"
 
       - name: Check for ESLint JUnit File
         id: check_eslint_junit

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -69,7 +69,12 @@ jobs:
           DD_ENV: ci
           NODE_OPTIONS: -r dd-trace/ci/init
         run: |
-          yarn test --ci --reporters=jest-junit 2> /dev/null || true
+          set +e
+          yarn test --ci --reporters=jest-junit --reporters=default
+          exitcode="$?"
+          
+          echo "exitcode=$?" >> $GITHUB_OUTPUT
+          exit "$exitcode"
 
       - name: Check for JUnit File
         id: check_junit

--- a/.github/workflows/stylelint.yml
+++ b/.github/workflows/stylelint.yml
@@ -59,12 +59,17 @@ jobs:
           DD_ENV: ci
           NODE_OPTIONS: -r dd-trace/ci/init
         run: |
-          yarn stylelint --formatter json --output-file stylelint-output.json 2> /dev/null || true
+          set +e
+          yarn stylelint --formatter json --output-file stylelint-output.json 1> /dev/null || true
+          exitcode="$?"
           
           if [ -f stylelint-output.json ]; then
             stylelint-duelie ./stylelint-output.json ./stylelint-output.xml
             rm stylelint-output.json
           fi
+          
+          echo "exitcode=$?" >> $GITHUB_OUTPUT
+          exit "$exitcode"
 
       - name: Check for StyleLint JUnit File
         id: check_stylelint_junit


### PR DESCRIPTION
This PR adds invalidation behavior for workflows above ☝️ 