### PR TITLE
feat(DEVOPS-20727): Remove --acl flag in s3 cli

### DIFF
--- a/.github/workflows/aws-deploy-s3.yml
+++ b/.github/workflows/aws-deploy-s3.yml
@@ -144,5 +144,4 @@ jobs:
              ./build/ \
              s3://hm-s3-bucket-${{ inputs.projectName }}-${{ inputs.env }}-ue1/ \
              --delete \
-             --cache-control "public, max-age=0, must-revalidate" \
-             --acl "bucket-owner-full-control"
+             --cache-control "public, max-age=0, must-revalidate"


### PR DESCRIPTION
## What? - Provide a description of what is being applied
- Update aws-deploy-s3 workflow to work without ACL

## Why? - Provide a description of why this is being implemented
- Due to compliance, ACL is being deprecated in favor of Object ownership being the Bucket Owner.

## Change?
- [ ] Creates and/or Destroy infrastructure
- [ ] In-place infrastructure updates
- [x] No changes to infrastructure
- [ ] Includes Prod Deployment

## Additional notes


## Review Checklist
### Self
- [x] The PR description and title are clear and provides enough context for the reviewer.
- [x] The PR is focused on a single feature and does not mix unrelated changes together.
- [x] The change implements what is described.
- [x] The code is correct.
- [x] The code is clear and readable.
  - Names are meaningful, and there are no typos.
  - Comments are added to explain complex logic.
  - Minimal duplicated code.

### Peer
- [x] The change implements what is described.
- [x] The code is correct.
- [x] The code is clear and readable.
  - Names are meaningful, and there are no typos.
  - Comments are added to explain complex logic.
  - Minimal duplicated code.